### PR TITLE
Fixed Last Checked Parsing

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Download recently changed data.
       run: |
         curl --compressed https://mcbroken2.nyc3.digitaloceanspaces.com/markers.json \
-          | jq '[ .features[] | select(.properties.last_checked | split(" ")[1] | tonumber < 31) ]' > mcbroken.json
+          | jq '[ .features[] | select(.properties.last_checked | match("[0-9]+").string | tonumber < 31) ]' > mcbroken.json
     - name: Commit data
       run: |
         git config user.name "Archive"


### PR DESCRIPTION
Fixed jq statement used to parse the number of minutes ago a store was
checked. Due to a recent change on mcbroken.com's end, number of minutes
ago parsing would fail since the numerical field is no longer always in
the second word of the .properties.last_checked field. Replace fixed
offset parsing with a regex match. This is slower, but more correct.